### PR TITLE
add a fading effect into the transition

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -43,6 +43,7 @@ class ThemeIndicator extends PanelMenu.Button {
     }
 
     _toggle_theme() {
+	Main.layoutManager.screenTransition.run();
         switch (this.schema.get_string('color-scheme')) {
             case LIGHT_SCHEME_NAME:
             case DEFAULT_SCHEME_NAME:


### PR DESCRIPTION
Apparently, gnome-shell provides a native and easy-to-use fade
transition effect method that's exposed publicly.

Thanks to: https://gitlab.gnome.org/fmuellner/quick-settings-extension/-/commit/0104c66ad0e7f31480815b2da5595e1a4bb70587