### PR TITLE
Add gnome version 43 as compatible version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Button in panel: switch between global dark and light themes. For GNOME Shell 42+.",
   "name": "Light/Dark Theme Switcher",
   "shell-version": [
-    "42"
+    "42", "43"
   ],
   "url": "https://github.com/fthx/theme-switcher",
   "uuid": "theme-switcher@fthx",


### PR DESCRIPTION
I have never worked on gnome extensions, so maybe other fields have to change, but it worked to pack and install the extension with this patch on gnome 43 for me